### PR TITLE
add P-touch CUBE Plus PTP710BT to list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ but have not been tested (please tell us if they do!):
  * Brother H500
  * Brother E500
 
+The following printers have been tested to mostly work, although not
+officially supported (their protocol is similar, although not identical):
+
+* Brother P-touch CUBE Plus PTP710BT
+
 The following backends are currently supported:
 
  * USB Printer Device Class via PyUSB


### PR DESCRIPTION
the raster command reference for the PT-E550W, PT-P750W and PT-P710BT is here: https://download.brother.com/welcome/docp100064/cv_pte550wp750wp710bt_eng_raster_101.pdf

Looking through, the command set seems to be nearly identical to that of the PT-H500/PT-P700/PT-E500 whose command reference is located here: https://download.brother.com/welcome/docp000771/cv_pth500p700e500_eng_raster_110.pdf


In testing (along with my bluetooth backend in #3), it seems to mostly work. the issues i've noticed are
1. the leading whitespace on the label is not trimmed before printing (not sure whether this is an issue with PT700 too?)
2. There is an error at the end of printing when trying to fetch the final status. I believe this is occurring because the code assumes the printer is operating in "Concurrent printing" mode (which seems to be the default over USB), but when connected over bluetooth, it seems to operate in "Buffered printing" mode. Increasing the timeout on the serial connection seems to fix the issue, but then causes delays with the `_debug_status()` checks (since they seem to usually not return any data). So probably best would be to just increase the timeout for that final status check (or to fully implement the status messages and phase changes to completely support buffered printing mode, but that seems like a fair bit of work)