### PR TITLE
add centered label class

### DIFF
--- a/labelprinterkit/label.py
+++ b/labelprinterkit/label.py
@@ -3,8 +3,12 @@ Labels are the Base class you derive your Labels from. A few simple Labels are
 provided for you.
 """
 from typing import Tuple
+import logging
 
 from PIL import Image
+
+
+logger = logging.getLogger(__name__)
 
 
 def _coord_add(tup1, tup2):
@@ -73,10 +77,10 @@ class Label:
             pos[1] += max(i.size[1] for i in line)
 
         xdim, ydim = img.size
-        print("presize", xdim, ydim, height)
+        logger.debug("presize %d %d %d", xdim, ydim, height)
         xdim = round((height / ydim) * xdim)
 
-        print("calcsize", xdim, ydim)
+        logger.debug("calcsize %d %d", xdim, ydim)
         img = img.resize((xdim, height))
 
         return img
@@ -108,10 +112,10 @@ class CenteredLabel(Label):
             pos[1] += max(i.size[1] for i in line)
 
         xdim, ydim = img.size
-        print("presize", xdim, ydim, height)
+        logger.debug("presize %d %d %d", xdim, ydim, height)
         xdim = round((height / ydim) * xdim)
 
-        print("calcsize", xdim, ydim)
+        logger.debug("calcsize %d %d", xdim, ydim)
         img = img.resize((xdim, height))
 
         return img

--- a/labelprinterkit/label.py
+++ b/labelprinterkit/label.py
@@ -82,3 +82,36 @@ class Label:
         return img
 
 # print("".join(f"{x:08b}".replace("0", " ") for x in bytes(i)))
+
+class CenteredLabel(Label):
+    def render(self, width=None, height=None) -> Image:
+        """render the Label.
+
+        Args:
+            width: Width request
+            height: Height request
+        """
+        size = self.size
+        img = Image.new("1", size, "white")
+
+        pos = [0, 0]
+
+        for line in self._rendered_items:
+            line_width = sum(item.size[0] for item in line)
+            # to center, offset by half of different between line width and total width
+            pos[0] = (size[0] - line_width) // 2
+            for item in line:
+                box = (*pos, *_coord_add(item.size, pos))
+                img.paste(item, box=box)
+                pos[0] += item.size[0]
+
+            pos[1] += max(i.size[1] for i in line)
+
+        xdim, ydim = img.size
+        print("presize", xdim, ydim, height)
+        xdim = round((height / ydim) * xdim)
+
+        print("calcsize", xdim, ydim)
+        img = img.resize((xdim, height))
+
+        return img


### PR DESCRIPTION
this class centers each line, rather than left-aligning. this allows for different sized lines of text to be centered together, for example

for a single text object spanning multiple lines, (eg if printing on a vertically-oriented label) it may make more sense to use an approach like this: https://gist.github.com/turicas/1455973